### PR TITLE
在Data.DataProviders中添加了wind数据接口

### DIFF
--- a/AlgoTrading/Backtest/StrategyRunner.py
+++ b/AlgoTrading/Backtest/StrategyRunner.py
@@ -105,13 +105,13 @@ def strategyRunner(userStrategy,
             freq = kwargs['freq']
         except KeyError:
             freq = 'D'
-            logger.info("No `freq` keyword arguments found. using default value as freq='D")
+            logger.info("No `freq` keyword arguments found. using default value as freq=D")
 
         try:
             priceAdj = kwargs['priceAdj']
         except KeyError:
-            priceAdj = 'N'
-            logger.info("No `priceAdj` keyword arguments found. using default value as priceAdj='N")
+            priceAdj = '0'
+            logger.info("No `priceAdj` keyword arguments found. using default value as priceAdj=0")
 
 
         dataHandler = WindMarketDataHandler(symbolList=symbolList,

--- a/AlgoTrading/Backtest/StrategyRunner.py
+++ b/AlgoTrading/Backtest/StrategyRunner.py
@@ -104,12 +104,21 @@ def strategyRunner(userStrategy,
         try:
             freq = kwargs['freq']
         except KeyError:
-            freq = 0
-            logger.info("No `freq` keyword arguments found. using default value as freq=0")
+            freq = 'D'
+            logger.info("No `freq` keyword arguments found. using default value as freq='D")
+
+        try:
+            priceAdj = kwargs['priceAdj']
+        except KeyError:
+            priceAdj = 'N'
+            logger.info("No `priceAdj` keyword arguments found. using default value as priceAdj='N")
+
+
         dataHandler = WindMarketDataHandler(symbolList=symbolList,
                                              startDate=startDate,
                                              endDate=endDate,
                                              freq=freq,
+                                             priceAdj=priceAdj,
                                              benchmark=benchmark,
                                              logger=logger)
 

--- a/AlgoTrading/Backtest/StrategyRunner.py
+++ b/AlgoTrading/Backtest/StrategyRunner.py
@@ -13,6 +13,7 @@ from AlgoTrading.Enums import PortfolioType
 from AlgoTrading.Utilities import CustomLogger
 from AlgoTrading.Data.DataProviders import HistoricalCSVDataHandler
 from AlgoTrading.Data.DataProviders import DataYesMarketDataHandler
+from AlgoTrading.Data.DataProviders import WindMarketDataHandler
 try:
     from AlgoTrading.Data.DataProviders import DXDataCenter
 except ImportError:
@@ -99,6 +100,18 @@ def strategyRunner(userStrategy,
                                         startDate=startDate,
                                         endDate=endDate,
                                         logger=logger)
+    elif dataSource == DataSource.WIND:
+        try:
+            freq = kwargs['freq']
+        except KeyError:
+            freq = 0
+            logger.info("No `freq` keyword arguments found. using default value as freq=0")
+        dataHandler = WindMarketDataHandler(symbolList=symbolList,
+                                             startDate=startDate,
+                                             endDate=endDate,
+                                             freq=freq,
+                                             benchmark=benchmark,
+                                             logger=logger)
 
     backtest = Backtest(initialCapital,
                         0.0,

--- a/AlgoTrading/Data/Data.py
+++ b/AlgoTrading/Data/Data.py
@@ -17,7 +17,18 @@ from AlgoTrading.Utilities.functions import categorizeSymbols
 
 
 def set_universe(code, refDate=None):
-    if Settings.data_source != DataSource.DXDataCenter:
+    if Settings.data_source == DataSource.WIND:
+        from WindPy import w
+        if not w.isconnected():
+            w.start()
+        if not refDate:
+            rawData = w.wset('IndexConstituent', 'windcode='+code)
+        else:
+            rawData = w.wset('IndexConstituent', 'date='+refDate, 'windcode='+code)
+        if len(rawData.Data) == 0:
+            return
+        return rawData.Data[0]
+    elif Settings.data_source != DataSource.DXDataCenter:
         import os
         import tushare as ts
 

--- a/AlgoTrading/Data/Data.py
+++ b/AlgoTrading/Data/Data.py
@@ -14,7 +14,7 @@ from AlgoTrading.Events import DayBeginEvent
 from AlgoTrading.Env import Settings
 from AlgoTrading.Enums import DataSource
 from AlgoTrading.Utilities.functions import categorizeSymbols
-
+from AlgoTrading.Utilities.functions import convert2WindSymbol
 
 def set_universe(code, refDate=None):
     if Settings.data_source == DataSource.WIND:
@@ -22,12 +22,15 @@ def set_universe(code, refDate=None):
         if not w.isconnected():
             w.start()
         if not refDate:
-            rawData = w.wset('IndexConstituent', 'windcode='+code, 'field=wind_code')
+            rawData = w.wset('IndexConstituent', 'windcode='+convert2WindSymbol(code), 'field=wind_code')
         else:
-            rawData = w.wset('IndexConstituent', 'date='+refDate, 'windcode='+code, 'field=wind_code')
+            rawData = w.wset('IndexConstituent', 'date='+refDate, 'windcode='+convert2WindSymbol(code), 'field=wind_code')
         if len(rawData.Data) == 0:
             return
-        return rawData.Data[0]
+        # convert to .xshg/.xshe suffix
+        idx = [s.replace('SH', 'xshg') for s in rawData.Data[0]]
+        idx = [s.replace('SZ', 'xshe') for s in idx]
+        return idx
     elif Settings.data_source != DataSource.DXDataCenter:
         import os
         import tushare as ts

--- a/AlgoTrading/Data/Data.py
+++ b/AlgoTrading/Data/Data.py
@@ -22,9 +22,9 @@ def set_universe(code, refDate=None):
         if not w.isconnected():
             w.start()
         if not refDate:
-            rawData = w.wset('IndexConstituent', 'windcode='+code)
+            rawData = w.wset('IndexConstituent', 'windcode='+code, 'field=wind_code')
         else:
-            rawData = w.wset('IndexConstituent', 'date='+refDate, 'windcode='+code)
+            rawData = w.wset('IndexConstituent', 'date='+refDate, 'windcode='+code, 'field=wind_code')
         if len(rawData.Data) == 0:
             return
         return rawData.Data[0]

--- a/AlgoTrading/Data/DataProviders/Wind.py
+++ b/AlgoTrading/Data/DataProviders/Wind.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+import numpy as np
+from AlgoTrading.Data.Data import DataFrameDataHandler
+from AlgoTrading.Utilities import transfromDFtoDict
+from WindPy import w
+
+
+_windSecIDMap = {'xshg': 'sh',
+                 'xshe': 'sz',
+                 'ccfx': 'cfe',# 中国金融期货交易所
+                 'xsge': 'shf', # 上海期货交易所
+                 'xzce': 'czc', # 郑州商品交易所
+                 'xdce':'dce'} # 大连期货交易所
+
+
+class WindMarketDataHandler(DataFrameDataHandler):
+
+    _req_args = ['symbolList', 'startDate', 'endDate', 'benchmark']
+
+    def __init__(self, **kwargs):
+        super(WindMarketDataHandler, self).__init__(kwargs['logger'], kwargs['symbolList'])
+        self.symbolList = [s.replace('xshg', 'sh') for s in self.symbolList]
+        self.symbolList = [s.replace('xshe', 'sz') for s in self.symbolList]
+        self.startDate = kwargs['startDate'].strftime("%Y%m%d")
+        self.endDate = kwargs['endDate'].strftime("%Y%m%d")
+        self._getDatas()
+        if kwargs['benchmark']:
+            self._getBenchmarkData(kwargs['benchmark'], self.startDate, self.endDate)
+
+
+    def _getDatas(self):
+        self.logger.info("Start loading bars from Wind source...")
+        combIndex = None
+        result = {}
+
+        for s in self.symbolList:
+            result[s] = getOneSymbolData((s, self.startDate, self.endDate))
+            self.logger.info("Symbol {0:s} is ready for back testing.".format(s))
+
+        for s in result:
+            if not result[s].empty:
+                self.symbolData[s] = result[s]
+                if combIndex is None:
+                    combIndex = self.symbolData[s].index
+                else:
+                    combIndex = combIndex.union(self.symbolData[s].index)
+
+                self.symbolData[s] = transfromDFtoDict(self.symbolData[s])
+
+        # transform
+        self.dateIndex = combIndex
+        self.start = 0
+        for i, s in enumerate(self.symbolList):
+            if s not in self.symbolData:
+                del self.symbolList[i]
+
+        self.logger.info("Bars loading finished!")
+
+    def _getBenchmarkData(self, indexID, startDate, endDate):
+        self.logger.info("Start loading benchmark {0:s} data from Wind source...".format(indexID))
+
+        indexData = getOneSymbolData((indexID, startDate, endDate))
+        indexData['return'] = np.log(indexData['close'] / indexData['close'].shift(1))
+        indexData = indexData.dropna()
+        self.benchmarkData = indexData
+
+        self.logger.info("Benchmark data loading finished!")
+
+    def updateInternalDate(self):
+        return False
+
+
+def getOneSymbolData(params):
+    s = params[0]
+    start = params[1]
+    end = params[2]
+    rawData = w.wsd(s,
+                 'open,high,low,close,volums',
+                 start,
+                 end,
+                 'Fill=Previous')
+
+    if len(rawData.Data) == 0:
+        return rawData
+    else:
+        output={'tradeDate':rawData.Times,
+                'open':rawData.Data[0],
+                'high':rawData.Data[1],
+                'low':rawData.Data[2],
+                'close':rawData.Data[3],
+                'volume':rawData.Data[4]}
+    data = pd.DataFrame(output)
+    data['tradeDate'] = data['tradeDate'].apply(lambda x: x.strftime('%Y-%m-%d'))
+    data = data.reset_index('tradeDate')
+    data.sort_index(inplace=True)
+    data.columns = ['open', 'high', 'low', 'close', 'volume']
+    return data

--- a/AlgoTrading/Data/DataProviders/Wind.py
+++ b/AlgoTrading/Data/DataProviders/Wind.py
@@ -3,6 +3,7 @@
 import pandas as pd
 import numpy as np
 from enum import IntEnum
+from enum import unique
 from AlgoTrading.Data.Data import DataFrameDataHandler
 from AlgoTrading.Utilities import transfromDFtoDict
 from WindPy import w
@@ -28,6 +29,8 @@ class WindMarketDataHandler(DataFrameDataHandler):
 
     def __init__(self, **kwargs):
         super(WindMarketDataHandler, self).__init__(kwargs['logger'], kwargs['symbolList'])
+        if not w.isconnected():
+            w.start()
         self.symbolList = [s.replace('xshg', 'sh') for s in self.symbolList]
         self.symbolList = [s.replace('xshe', 'sz') for s in self.symbolList]
         self.startDate = kwargs['startDate'].strftime("%Y%m%d")
@@ -90,7 +93,7 @@ def getOneSymbolData(params):
                      'open,high,low,close,volums',
                      start,
                      end,
-                     'Fill=Previous')
+                     'Fill=Previous, PriceAdj=F')
     else:
         rawData = w.wsi(s,
                         'open,high,low,close,volums',

--- a/AlgoTrading/Data/DataProviders/Wind.py
+++ b/AlgoTrading/Data/DataProviders/Wind.py
@@ -30,7 +30,7 @@ class FreqType(StrEnum):
 
 @unique
 class PriceAdjType(StrEnum):
-    NoAdj = 'N'
+    NoAdj = '0'
     Forward = 'F'   # 前复权
     Backward = 'B'  # 后复权
 

--- a/AlgoTrading/Data/DataProviders/Wind.py
+++ b/AlgoTrading/Data/DataProviders/Wind.py
@@ -105,13 +105,13 @@ def getOneSymbolData(params):
                      'open,high,low,close,volume',
                      start,
                      end,
-                     'PriceAdj='+priceAdj, 'Period='+freq)
+                     'PriceAdj='+priceAdj, 'Period='+freq, 'Fill=Previous')
     else:
         rawData = w.wsi(s,
                         'open,high,low,close,volume',
                         start,
                         end,
-                        'Barsize='+freq[3:])
+                        'Barsize='+freq[3:], 'Fill=Previous')
 
     if len(rawData.Data) == 0:
         return rawData

--- a/AlgoTrading/Data/DataProviders/Wind.py
+++ b/AlgoTrading/Data/DataProviders/Wind.py
@@ -84,7 +84,7 @@ def getOneSymbolData(params):
                      'open,high,low,close,volume',
                      start,
                      end,
-                     'Fill=Previous, PriceAdj=F')
+                     'PriceAdj=F')
     else:
         rawData = w.wsi(s,
                         'open,high,low,close,volume',

--- a/AlgoTrading/Data/DataProviders/__init__.py
+++ b/AlgoTrading/Data/DataProviders/__init__.py
@@ -7,6 +7,7 @@ Created on 2015-9-21
 
 from AlgoTrading.Data.DataProviders.CSVFiles import HistoricalCSVDataHandler
 from AlgoTrading.Data.DataProviders.DataYes import DataYesMarketDataHandler
+from AlgoTrading.Data.DataProviders.Wind import WindMarketDataHandler
 try:
     from AlgoTrading.Data.DataProviders.DongXingDataCenter import DXDataCenter
 except ImportError:

--- a/AlgoTrading/Data/DataProviders/__init__.py
+++ b/AlgoTrading/Data/DataProviders/__init__.py
@@ -16,4 +16,5 @@ from AlgoTrading.Data.DataProviders.YaHoo import YaHooDataProvider
 __all__ = ["HistoricalCSVDataHandler",
            "DataYesMarketDataHandler",
            "DXDataCenter",
-           "YaHooDataProvider"]
+           "YaHooDataProvider",
+           "WindMarketDataHandler"]

--- a/AlgoTrading/Data/__init__.py
+++ b/AlgoTrading/Data/__init__.py
@@ -18,4 +18,5 @@ __all__ = ['set_universe',
            'HistoricalCSVDataHandler',
            'DataYesMarketDataHandler',
            'DXDataCenter',
-           'YaHooDataProvider']
+           'YaHooDataProvider',
+           'WindMarketDataHanlder']

--- a/AlgoTrading/Enums/__init__.py
+++ b/AlgoTrading/Enums/__init__.py
@@ -14,6 +14,7 @@ class DataSource(IntEnum):
     DataYes = 1
     DXDataCenter = 2
     YAHOO = 3
+    WIND = 4
 
 
 @unique

--- a/AlgoTrading/Utilities/functions.py
+++ b/AlgoTrading/Utilities/functions.py
@@ -5,8 +5,36 @@ Created on 2016-2-4
 @author: cheng.li
 """
 
-
+import re
 from AlgoTrading.Events import OrderDirection
+
+
+
+_windIndexSuffixDict = {'000[0-9]*': 'sh', # 上证指数、中证指数
+                          '399[0-9]*': 'sz', # 深证指数、国证规模指数
+                          '899[0-9]*': 'csi', # 三板指数
+                        '80[0-9]*': 'si', # 申万行业指数
+                        'CI[0-9]*': 'wi'} # 中信行业指数
+
+
+_windExchangeDict = {'xshg': 'sh',
+                 'xshe': 'sz',
+                 'ccfx': 'cfe',# 中国金融期货交易所
+                 'xsge': 'shf', # 上海期货交易所
+                 'xzce': 'czc', # 郑州商品交易所
+                 'xdce':'dce'} # 大连期货交易所
+
+
+
+def convert2WindSymbol(symbol):
+    symbolComp = symbol.split('.')
+    if symbolComp[1] == 'zicn':
+        for patterns in _windIndexSuffixDict:
+            if re.match(patterns, symbolComp[0]):
+                return symbolComp[0] + '.'+ _windIndexSuffixDict[patterns]
+        raise ValueError('{0} and {1} pair is not recognized'.format(symbolComp[0], symbolComp[1]))
+    else:
+        return symbolComp[0] + '.' + _windExchangeDict[symbolComp[1]]
 
 
 def sign(x):

--- a/AlgoTrading/examples/WindBasedStrategy.py
+++ b/AlgoTrading/examples/WindBasedStrategy.py
@@ -32,8 +32,8 @@ class MovingAverageCrossStrategy(Strategy):
 
 
 def run_example():
-    universe = set_universe('000300.zicn')[:200]
-    startDate = dt.datetime(2001, 12, 1)
+    universe = set_universe('000300.zicn', refDate='2015-01-01')[:200]
+    startDate = dt.datetime(2015, 1, 1)
     endDate = dt.datetime(2017, 1, 1)
 
     strategyRunner(userStrategy=MovingAverageCrossStrategy,

--- a/AlgoTrading/examples/WindBasedStrategy.py
+++ b/AlgoTrading/examples/WindBasedStrategy.py
@@ -32,20 +32,20 @@ class MovingAverageCrossStrategy(Strategy):
 
 
 def run_example():
-    universe = set_universe('000300.zicn')[:2]
-    startDate = dt.datetime(2001, 1, 1)
+    universe = set_universe('000300.zicn')[:200]
+    startDate = dt.datetime(2001, 12, 1)
     endDate = dt.datetime(2017, 1, 1)
 
     strategyRunner(userStrategy=MovingAverageCrossStrategy,
                    symbolList=universe,
                    startDate=startDate,
                    endDate=endDate,
-                   freq=0,
                    benchmark='000300.zicn',
                    dataSource=DataSource.WIND,
                    logLevel='info',
                    saveFile=True,
-                   plot=True)
+                   plot=True,
+                   freq='D')
 
 
 if __name__ == "__main__":

--- a/AlgoTrading/examples/WindBasedStrategy.py
+++ b/AlgoTrading/examples/WindBasedStrategy.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+u"""
+Created on 2015-9-23
+
+@author: cheng.li
+"""
+
+import datetime as dt
+
+from AlgoTrading.api import Strategy
+from AlgoTrading.api import strategyRunner
+from AlgoTrading.api import DataSource
+from AlgoTrading.api import set_universe
+from PyFin.api import MA
+from PyFin.api import MAX
+from PyFin.api import MIN
+
+
+class MovingAverageCrossStrategy(Strategy):
+    def __init__(self):
+        filtering = (MAX(10, 'close') / MIN(10, 'close')) >= 1.00
+        indicator = MA(10, 'close') - MA(120, 'close')
+        self.signal = indicator[filtering]
+
+    def handle_data(self):
+        for s in self.universe:
+            amount = self.avaliableForSale(s)
+            if self.signal[s] > 0. and self.secPos[s] == 0:
+                self.order(s, 1, quantity=200)
+            if self.signal[s] < 0. and amount != 0:
+                self.order(s, -1, quantity=200)
+
+
+def run_example():
+    universe = set_universe('000300.zicn')[:2]
+    startDate = dt.datetime(2001, 1, 1)
+    endDate = dt.datetime(2017, 1, 1)
+
+    strategyRunner(userStrategy=MovingAverageCrossStrategy,
+                   symbolList=universe,
+                   startDate=startDate,
+                   endDate=endDate,
+                   freq=0,
+                   benchmark='000300.zicn',
+                   dataSource=DataSource.WIND,
+                   logLevel='info',
+                   saveFile=True,
+                   plot=True)
+
+
+if __name__ == "__main__":
+    from VisualPortfolio.Env import Settings
+    from AlgoTrading.Env import Settings
+    Settings.set_source(DataSource.WIND)
+    startTime = dt.datetime.now()
+    print("Start: %s" % startTime)
+    run_example()
+    endTime = dt.datetime.now()
+    print("End : %s" % endTime)
+    print("Elapsed: %s" % (endTime - startTime))


### PR DESCRIPTION
依赖：
- 安装windpy， 在wind终端中依照提示安装即可

功能
1- 在Data.DataProviders中添加了wind.py，入参包括，代码列表，起始日，频率， 复权等。 为保持风格的统一，入参中的代码后缀和DataYes代码类型一致，为.xshe/.xshg/.zicn 等， 内部会自动转换成wind类的后缀(.sh, .sz) ，其他参数设置请见代码
2- set_universe中也添加了wind的接口， 可以设置时间(refDate)
3- 在example中添加了windbasedstrategy， 和DataYesbasedStrategy逻辑完全一致，只是修改了数据源

使用时请注意wind服务器提取代码的上限， 每周50万条。